### PR TITLE
Turn off cors for json files

### DIFF
--- a/.utils/deploy.sh
+++ b/.utils/deploy.sh
@@ -75,7 +75,7 @@ aws s3 sync \
   --content-type "application/json" \
   --exclude "*" \
   --include "*.json" \
-  --metadata "{${ACAO}, ${HSTS}, ${TYPE}}" \
+  --metadata "{${HSTS}, ${TYPE}}" \
   --metadata-directive "REPLACE" \
   --acl "public-read" \
   ${ARTIFACTS}/ s3://${CONCEPTS_BUCKET}/


### PR DESCRIPTION
Except __version__ which still allows all origins to use cors.

This will hopefully fix https://github.com/mozilla/concepts/issues/27#issuecomment-467365780