### PR TITLE
Set the x-amz-website-redirect-location property

### DIFF
--- a/.utils/deploy.sh
+++ b/.utils/deploy.sh
@@ -114,6 +114,7 @@ for fn in $(find ${ARTIFACTS} -name 'index.html' -not -path '${ARTIFACTS}/index.
     --include "*.html" \
     --metadata "{${CSP//$'\n'/ }, ${HSTS}, ${TYPE}, ${XSS}}" \
     --metadata-directive "REPLACE" \
+    --website-redirect "/${s3path}/"  \
     --acl "public-read" \
     $fn s3://${CONCEPTS_BUCKET}/${s3path}
 done


### PR DESCRIPTION
For the object that represents the index.html file of the same name directory.

This is per https://bugzilla.mozilla.org/show_bug.cgi?id=1619765. The deployment
script already creates a same named object for any directory that contains an
index.html file. We now set the x-amz-website-redirect-location for this object
so that access to `/betterweb` for example, gets 301 redirected to `/betterweb/`.